### PR TITLE
CSockets: a Symja backend

### DIFF
--- a/Packages/CSockets/Kernel/CSockets.wl
+++ b/Packages/CSockets/Kernel/CSockets.wl
@@ -10,9 +10,13 @@
 
 BeginPackage["CoffeeLiqueur`CUSockets`"]; 
 
-Needs @ If[$OperatingSystem === "Windows",  
-	"CoffeeLiqueur`CUSockets`Interface`Windows`", 
-	"CoffeeLiqueur`CUSockets`Interface`Unix`"
+Needs @ Which[
+	StringStartsQ[ToString[$Version], "Symja"],
+		"CoffeeLiqueur`CUSockets`Interface`Symja`",
+	$OperatingSystem === "Windows",
+		"CoffeeLiqueur`CUSockets`Interface`Windows`",
+	True,
+		"CoffeeLiqueur`CUSockets`Interface`Unix`"
 ];
 
 (* ::Section:: *)
@@ -99,7 +103,9 @@ socketClose[socketId];
 
 StandardSocketEventsHandler = Echo[StringTemplate["`` was ``"][#2, #1] ]&;
 
-USocketObject /: SocketListen[socket: USocketObject[socketId_Integer], handler_, OptionsPattern[{SocketListen, "BufferSize" -> $bufferSize, "SocketEventsHandler" -> StandardSocketEventsHandler}]] := 
+Options[usocketListen] = {"BufferSize" -> $bufferSize, "SocketEventsHandler" -> StandardSocketEventsHandler};
+
+usocketListen[socket: USocketObject[socketId_Integer], handler_, OptionsPattern[]] :=
 With[{messager = OptionValue["SocketEventsHandler"]},
 	Module[{task}, 
 		task = createAsynchronousTask[socketId, 
@@ -114,8 +120,15 @@ With[{messager = OptionValue["SocketEventsHandler"]},
 			"TaskId" -> task[[2]], 
 			"Task" -> task
 		|>]
-	]; 
+	]
 ];
+
+(* Keep the upvalue patterns simple enough for alternative WL evaluators. *)
+USocketObject /: SocketListen[USocketObject[socketId_Integer], handler_] :=
+	usocketListen[USocketObject[socketId], handler];
+
+USocketObject /: SocketListen[USocketObject[socketId_Integer], handler_, opts__Rule] :=
+	usocketListen[USocketObject[socketId], handler, opts];
 
 
 USocketListener /: DeleteObject[USocketListener[assoc_Association]] := 

--- a/Packages/CSockets/Kernel/Symja.wl
+++ b/Packages/CSockets/Kernel/Symja.wl
@@ -1,0 +1,114 @@
+BeginPackage["CoffeeLiqueur`CUSockets`Interface`Symja`"]
+
+createAsynchronousTask;
+socketOpen;
+socketClose;
+socketBinaryWrite;
+socketWriteString;
+
+socketConnect;
+socketConnectInternal;
+
+socketReadyQ;
+socketReadMessage;
+socketPort;
+socketListenerTaskRemove;
+
+
+Begin["`Private`"]
+
+
+Echo["CSockets >> Symja >> Using native sockets"];
+
+$nextSocketId = 0;
+
+registerNativeSocket[socket_] := Module[{uuid, id},
+    uuid = socket["UUID"];
+    id = socketIds[uuid];
+
+    If[IntegerQ[id], Return[id]];
+
+    id = $nextSocketId = $nextSocketId + 1;
+    socketIds[uuid] = id;
+    nativeSockets[id] = socket;
+    socketsInfo[id] = socket["DestinationPort"];
+    id
+];
+
+socketOpen[host_String, port_String] :=
+    registerNativeSocket[SocketOpen[host, ToExpression[port]]];
+
+socketConnect[host_String, port_String] :=
+    registerNativeSocket[SocketConnect[host, ToExpression[port]]];
+
+socketConnectInternal[socketId_Integer] := With[{
+    socket = nativeSockets[socketId]
+},
+    registerNativeSocket[SocketConnect[
+        socket["DestinationHostname"],
+        socket["DestinationPort"]
+    ]]
+];
+
+socketClose[socketId_Integer] := With[{result = Close[nativeSockets[socketId]]},
+    If[result === $Failed, -1, 0]
+];
+
+socketBinaryWrite[socketId_Integer, data_ByteArray, length_Integer, bufferSize_Integer] :=
+With[{result = BinaryWrite[nativeSockets[socketId], data]},
+    If[result === $Failed, -1, length]
+];
+
+socketWriteString[socketId_Integer, data_String, length_Integer, bufferSize_Integer] :=
+With[{result = WriteString[nativeSockets[socketId], data]},
+    If[result === $Failed, -1, length]
+];
+
+socketReadyQ[socketId_Integer] := SocketReadyQ[nativeSockets[socketId]];
+
+socketReadMessage[socketId_Integer, size_Integer] :=
+    SocketReadMessage[nativeSockets[socketId], size];
+
+socketPort[socketId_Integer] := If[IntegerQ[socketsInfo[socketId]],
+    socketsInfo[socketId],
+    -1
+];
+
+forwardAccepted[event_] := (registerNativeSocket[event["SourceSocket"]]; Null);
+
+forwardReceived[serverId_Integer, handler_][event_] := Module[{clientId},
+    clientId = registerNativeSocket[event["SourceSocket"]];
+    handler[serverId, "Received", {
+        serverId,
+        clientId,
+        Normal[event["DataByteArray"]]
+    }]
+];
+
+forwardSocketEvent[name_String, serverId_Integer, handler_][event_] := Module[{clientId},
+    clientId = registerNativeSocket[event["SourceSocket"]];
+    handler[serverId, name, {serverId, clientId, {}}]
+];
+
+Options[createAsynchronousTask] = {"BufferSize" -> 2^11};
+
+createAsynchronousTask[socketId_Integer, handler_, OptionsPattern[]] := Module[{listener},
+    listener = SocketListen[
+        nativeSockets[socketId],
+        HandlerFunctions -> <|
+            "Accepted" -> forwardAccepted,
+            "Received" -> forwardReceived[socketId, handler],
+            "Closed" -> forwardSocketEvent["Closed", socketId, handler],
+            "Error" -> forwardSocketEvent["Error", socketId, handler]
+        |>
+    ];
+    listenerObjects[listener[[1]]] = listener;
+    {listener, listener[[1]]}
+];
+
+socketListenerTaskRemove[listenerId_Integer] :=
+    DeleteObject[listenerObjects[listenerId]];
+
+
+End[]
+EndPackage[]

--- a/Packages/CSockets/PacletInfo.wl
+++ b/Packages/CSockets/PacletInfo.wl
@@ -18,7 +18,8 @@ PacletObject[
           {"CoffeeLiqueur`CUSockets`", "CSockets.wl"}, 
           {"CoffeeLiqueur`CUSockets`EventsExtension`", "EventsExtension.wl"},
           {"CoffeeLiqueur`CUSockets`Interface`Windows`", "Windows.wl"},
-          {"CoffeeLiqueur`CUSockets`Interface`Unix`", "Unix.wl"}
+          {"CoffeeLiqueur`CUSockets`Interface`Unix`", "Unix.wl"},
+          {"CoffeeLiqueur`CUSockets`Interface`Symja`", "Symja.wl"}
         },
         "Symbols" -> {
           "CoffeeLiqueur`CUSockets`USocketObject",


### PR DESCRIPTION
This is a draft the other parts from Symja symjascript  project are missing at the moment.

Symja's [symjascript](https://github.com/axkr/symjascript) now has the standard socket functions: SocketOpen, SocketConnect, SocketListen with HandlerFunctions, SocketReadMessage, Close. 
No LibraryLink is involved, which is what makes it possible at all.

Selected by $Version.

The SocketListen upvalue is also split into two plain patterns, so an evaluator without OptionsPattern-in-an-upvalue can still take it.